### PR TITLE
Use website in print and inline @ separators

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -77,8 +77,8 @@ ul.tags{display:flex;flex-wrap:wrap;gap:10px;list-style:none;padding:0;margin:.6
 ul.tags li{padding:4px 8px;border:1px solid var(--accent);border-radius:0;background:rgba(0,212,106,0.08)}
 
 /* Languages meter (overall bar per language) */
-ul.langs{list-style:none;padding:0;margin:.6rem 0 1.2rem;display:grid;gap:8px}
-ul.langs li{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+ul.langs{display:flex;flex-wrap:wrap;gap:10px;list-style:none;padding:0;margin:.6rem 0 1.2rem}
+ul.langs li{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:4px 8px;border:1px solid var(--accent);border-radius:0;background:rgba(0,212,106,0.08)}
 ul.langs .name{font-weight:600}
 .meter{display:grid;grid-auto-flow:column;gap:4px}
 .meter .cell{width:14px;height:8px;border:1px solid var(--accent);background:transparent}
@@ -89,10 +89,12 @@ ul.langs .name{font-weight:600}
 .role{font-weight:600}
 .company{font-weight:600}
 .dates{color:var(--muted)}
+
 .small{font-size:.97em;color:var(--muted)}
+.print-only{display:none}
 
 /* Separator between role and company as colored "@" */
-.item .role::after{content:" @ "; color:var(--accent-2); font-weight:700}
+.item .at{color:var(--accent-2);font-weight:700}
 
 
 /* Download button (stand-out cyan) */
@@ -151,8 +153,9 @@ h2 .bi{width:1.15em;margin-right:8px;text-align:center;vertical-align:.0em;color
   hr{border-top:1px solid #000}
   section h2{color:#000;margin:.3rem 0 .45rem}
 
-  /* Color of inserted @ for print */
-  .item .role::after{ color:#000 !important }
+  /* Color of @ separator for print */
+  .item .at{ color:#000 !important }
+  .print-only{display:inline !important}
 
   /* Layout tightening */
   .container{padding:0}

--- a/index.md
+++ b/index.md
@@ -12,7 +12,9 @@ title: "Mohammed Laroussi — Resume"
       <a href="mailto:{{ site.data.resume.email }}"><i class="bi bi-envelope"></i> {{ site.data.resume.email }}</a> ·
       <i class="bi bi-telephone"></i> {{ site.data.resume.phone }}
       {% assign li = site.data.resume.links | where: "label", "LinkedIn" | first %}
+      {% assign web = site.data.resume.links | where: "label", "Website" | first %}
       <span class="no-print"> · <a href="{{ li.url }}"><i class="bi bi-linkedin"></i> LinkedIn</a></span>
+      <span class="print-only"> · <a href="{{ web.url }}">Laroussi.me</a></span>
     </div>
   </div>
   <div class="no-print header-actions">
@@ -55,14 +57,13 @@ title: "Mohammed Laroussi — Resume"
       {% assign n = l.score | default: 4 | plus: 0 %}
       {% if n > 5 %}{% assign n = 5 %}{% endif %}
       {% if n < 0 %}{% assign n = 0 %}{% endif %}
-      <li>
+      <li{% if l.level %} title="{{ l.level }}"{% endif %}>
         <span class="name">{{ l.name }}</span>
         <span class="meter" aria-label="Overall proficiency {{ n }}/5">
           {% for i in (1..5) %}
           <span class="cell {% if i <= n %}on{% endif %}"></span>
           {% endfor %}
         </span>
-        {% if l.level %}<span class="lvl small no-print">{{ l.level }}</span>{% endif %}
       </li>
       {% endfor %}
     </ul>
@@ -85,7 +86,7 @@ title: "Mohammed Laroussi — Resume"
     <h2><i class="bi bi-briefcase"></i> Experience</h2>
     {% for job in site.data.resume.experience %}
     <div class="item">
-      <span class="role">{{ job.role }}</span> <span class="company">{{ job.company }}</span> · <span class="dates">{{ job.dates }}</span>
+      <span class="role">{{ job.role }}</span> <span class="at">@</span> <span class="company">{{ job.company }}</span> · <span class="dates">{{ job.dates }}</span>
       <ul class="compact">
         {% for b in job.bullets %}<li>{{ b }}</li>{% endfor %}
       </ul>


### PR DESCRIPTION
## Summary
- Show Laroussi.me when printing the resume while keeping LinkedIn visible on screen only
- Replace CSS-generated role/company separator with an inline @ element

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll -N` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a1eaf4c832890ab9a6756f0e4d4